### PR TITLE
Make dataDiff method public and add getOriginalState method

### DIFF
--- a/src/Rest/Base.php
+++ b/src/Rest/Base.php
@@ -366,7 +366,12 @@ abstract class Base extends \stdClass
         }
     }
 
-    private static function dataDiff(array $data1, array $data2): array
+    public function getOriginalState(): array
+    {
+        return $this->originalState;
+    }
+
+    public static function dataDiff(array $data1, array $data2): array
     {
         $diff = array();
 


### PR DESCRIPTION
The dataDiff method in Base.php has been modified from private to public, increasing its accessibility. Additionally, a new method getOriginalState has been added which returns the original state of the data.
